### PR TITLE
Fixes Ruby warnings

### DIFF
--- a/lib/multiprocessing.rb
+++ b/lib/multiprocessing.rb
@@ -23,7 +23,7 @@ module MultiProcessing
   # documentation is at below
   if Thread.respond_to?(:handle_interrupt)
     def try_handle_interrupt *args, &block
-      Thread.handle_interrupt *args, &block
+      Thread.handle_interrupt(*args, &block)
     end
   else
     def try_handle_interrupt *args

--- a/lib/multiprocessing/externalobject.rb
+++ b/lib/multiprocessing/externalobject.rb
@@ -9,7 +9,7 @@ module MultiProcessing
       @result_queue = Queue.new
       @mutex = Mutex.new
       @closed = false
-      @pid = fork{|obj| process_loop obj }
+      @pid = fork{|o| process_loop o }
     end
 
     def process_loop obj
@@ -17,7 +17,7 @@ module MultiProcessing
         *args = @call_queue.deq
         result = nil
         begin
-          result = obj.__send__ *args
+          result = obj.__send__(*args)
         rescue => e
           result = e
         end
@@ -45,7 +45,7 @@ module MultiProcessing
     end
 
     def method_missing *args
-      self.send *args
+      self.send(*args)
     end
 
   end

--- a/lib/multiprocessing/mutex.rb
+++ b/lib/multiprocessing/mutex.rb
@@ -66,7 +66,7 @@ module MultiProcessing
           @pout.read_nonblock 1
           @pin.syswrite 1
           false
-        rescue Errno::EAGAIN => e
+        rescue Errno::EAGAIN
           true
         end
       end

--- a/lib/multiprocessing/queue.rb
+++ b/lib/multiprocessing/queue.rb
@@ -145,7 +145,7 @@ module MultiProcessing
       raise QueueError.new("already closed") if @closed
       unless(@enq_thread && @enq_thread.alive?)
         @enq_queue.clear
-        @enq_thread = Thread.new &method(:enq_loop)
+        @enq_thread = Thread.new(&method(:enq_loop))
       end
       @enq_queue.enq(Marshal.dump(obj))
       @count.post


### PR DESCRIPTION
Hey @clicube, thanks for this great gem! It's used in [pgsync](https://github.com/ankane/pgsync). This fixes the following Ruby warnings:

```
lib/multiprocessing.rb:26: warning: `*' interpreted as argument prefix
lib/multiprocessing/mutex.rb:69: warning: assigned but unused variable - e
lib/multiprocessing/queue.rb:148: warning: `&' interpreted as argument prefix
lib/multiprocessing/externalobject.rb:12: warning: shadowing outer local variable - obj
lib/multiprocessing/externalobject.rb:20: warning: `*' interpreted as argument prefix
lib/multiprocessing/externalobject.rb:48: warning: `*' interpreted as argument prefix
```
